### PR TITLE
set Version to 5.0.1, Add automatic conversion of external link to re…

### DIFF
--- a/HidePasswordReset.php
+++ b/HidePasswordReset.php
@@ -10,22 +10,39 @@ namespace Piwik\Plugins\HidePasswordReset;
 
 class HidePasswordReset extends \Piwik\Plugin
 {
-	public function registerEvents()
+    public function registerEvents()
     {
         return array(
             'Template.loginNav' => 'commentOutElement',
-			'Template.loginNav' => 'commentOutElement',
+            'Template.loginNav' => 'commentOutElement',
         );
     }
-	
-	public function commentOutElement(&$outString,$area){
-		if($area === "top"){
-			$outString = "<!--";
-		}else if($area === "bottom"){
-			$outString = "-->";
-			
-			$settings = new SystemSettings();
-			$outString .= \Piwik\Common::sanitizeInputValues($settings->message->getValue());
-		}
-	}
+
+    public function commentOutElement(&$outString,$area){
+        if($area === "top"){
+            $outString = "<!--";
+        }else if($area === "bottom"){
+            $outString = "-->";
+
+            $settings = new SystemSettings();
+            $string = \Piwik\Common::sanitizeInputValues($settings->message->getValue());
+            if ( strlen( $string ) < 4 ) {
+                $outString .= $string ;
+            } else {
+                $stringExplode = explode(" " , $string ) ;
+                foreach ( $stringExplode as $part ) {
+                    if(substr( $part , 0 , 8) == "https://") {
+                        $outString .= '<a href="' . $part . '" target="_blank">' . $part . "</a> " ;
+                    } else {
+                        $outString .= $part . ' ' ;
+                    }
+                }
+                unset($stringExplode);
+                unset($part);
+            }
+            unset($string) ;
+
+
+        }
+    }
 }

--- a/README.md
+++ b/README.md
@@ -2,7 +2,12 @@
 
 ## Description
 
-Hides the "Lost your password?" option on login form. This plugin was created to prevent user confusion when using a central identity management platform such as LDAP or SAML.
+Hides the "Lost your password?" option on login form. 
+This plugin was created to prevent user confusion when using a central identity management platform such as LDAP or SAML.
+
+new in Version 5.0:
+if the replacement login message contains "https://", the URL is automatically converted to a link
+
 
 ## License
 GPL v3 / fair use

--- a/docs/index.md
+++ b/docs/index.md
@@ -3,3 +3,7 @@
 The easiest way to install is to find the plugin in the [Matomo Marketplace](https://plugins.matomo.org/).
 Just Activate on the plugin page after install and the "Lost your password?" message will be removed.
 A replacement login message may be supplied on the General Settings screen (see screenshots).
+
+new in Version 5.0:
+if the replacement login message contains "https://", the URL is automatically converted to a link 
+

--- a/plugin.json
+++ b/plugin.json
@@ -1,10 +1,10 @@
 {
     "name": "HidePasswordReset",
     "description": "Hides the Lost your password? option on login form and allows to replace with a different message.",
-    "version": "4.3.3",
+    "version": "5.0.0",
     "theme": false,
     "require": {
-        "matomo": ">=4.0.0-b1,<5.0.0-b1"
+        "matomo": ">=4.0.0-b1,<6.0.0-b1"
     },
     "authors": [
         {


### PR DESCRIPTION
What did i do:

Changed Version in plugin.json to allow also matomo Version 5.x 

Changed HidePasswordRest.php to check if string contains a link to an external URL, starting with https://, and make that Url clickable 

so the text :

Please request a new password on: https://ldap.myDomain.com 

will be

Please request a new password on: [https://ldap.myDomain.com](https://ldap.myDomain.com )
 