### PR TITLE
Patched to remove new "Lost Your Password?" link included in matomo 5.4.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,3 +6,4 @@
 - 1.3.0 Fixed error upon login
 - 1.3.3 Reorganized docs and implemented new marketplace webhook
 - 4.3.3 Matomo 4 compatibility (just modified plugin.json)
+- 5.4.0 Added Translation filter to remove Login_LostYourPassword that is presented in Matomo version >=5.4.0

--- a/TranslationsFilter.php
+++ b/TranslationsFilter.php
@@ -1,0 +1,31 @@
+<?php
+
+namespace Piwik\Plugins\HidePasswordReset;
+
+
+use Piwik\Translation\Loader\JsonFileLoader;
+
+class TranslationsFilter extends JsonFileLoader
+{
+    private $logger;
+
+    //Inject logger
+    public function __construct(\Piwik\Log\LoggerInterface $logger) {
+        $this->logger = $logger;
+    }
+
+    //Overwrite Translations loaders load function and blank Login_LostYourPassword so that it is not displayed.
+    public function load($language, array $directories) {
+        $translations = parent::load($language, $directories);
+
+        //Silently fail if key not found.
+        try{
+            $translations["Login"]["LostYourPassword"] = "";   
+        }
+        catch(Exception $e){
+            $this->logger->error('HidePasswordRest plugin. An error occurred while attempting to blank Login_LostYourPassword in translations', array('exception' => $e));
+        }
+                             
+        return $translations;
+    }
+}

--- a/config/config.php
+++ b/config/config.php
@@ -1,0 +1,5 @@
+<?php
+
+return array(
+    'Piwik\Translation\Loader\JsonFileLoader' => DI\autowire('Piwik\Plugins\HidePasswordReset\TranslationsFilter'),
+);

--- a/plugin.json
+++ b/plugin.json
@@ -1,7 +1,7 @@
 {
     "name": "HidePasswordReset",
     "description": "Hides the Lost your password? option on login form and allows to replace with a different message.",
-    "version": "5.0.0",
+    "version": "5.4.0",
     "theme": false,
     "require": {
         "matomo": ">=4.0.0-b1,<6.0.0-b1"


### PR DESCRIPTION
Added translations loader override to blank Login_LostYourPassword. This hides the new Lost Your Password? link that was added in Matomo 5.4.0. 
Fixed #6 